### PR TITLE
fixes #13

### DIFF
--- a/R/rcloud.shiny.R
+++ b/R/rcloud.shiny.R
@@ -47,7 +47,7 @@ rcloud.shinyApp <- function(ui, server, options) {
   appHandlers <- shiny:::createAppHandlers(NULL, serverFuncSource)
   app <- override.shinyApp(ui = ui, server = server)
 
-  host <- rcloud.get.conf.value('host')
+  host <- Sys.info()['nodename']
   appInfo <- override.runApp(app, host=nsl(host))
 
   rcloud.shiny.caps$init(ocaps);


### PR DESCRIPTION
Instead of using the host from rcloud.conf, rcloud.ShinyApp should use the nodename of the host it's running on. This resolves the error "Failed to create server". But there are more problems to solve in order to get shiny apps running on RCloud 1.7...