### PR TITLE
Shiny in the cell and implementation of print shiny.appobj

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Version: 0.5
 Author: Gordon Woodhull <gordon@research.att.com>
 Maintainer: Gordon Woodhull <gordon@research.att.com>
 Description: rcloud.shiny connects a Shiny app to an RCloud server using ocaps instead of websockets
-Depends: rcloud.support (>= 1.8-0)
-Suggests: rcloud.web, shiny (>= 0.14)
+Depends: rcloud.support (>= 1.8-0), shiny (>= 0.14)
+Suggests: rcloud.web
 NOTE: --- packages that are not on CRAN/RForge.net *must* be in Suggests! ---
 License: GPL-3, MIT

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,6 +4,7 @@ Version: 0.4.2
 Author: Gordon Woodhull <gordon@research.att.com>
 Maintainer: Gordon Woodhull <gordon@research.att.com>
 Description: rcloud.shiny connects a Shiny app to an RCloud server using ocaps instead of websockets
-Depends: rcloud.support (>= 1.6-0), shiny (>= 0.14)
+Depends: rcloud.support (>= 1.8-0)
+Suggests: rcloud.web, shiny (>= 0.14)
 NOTE: --- packages that are not on CRAN/RForge.net *must* be in Suggests! ---
 License: GPL-3, MIT

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rcloud.shiny
 Title: Shiny Support for RCloud
-Version: 0.4.2
+Version: 0.5
 Author: Gordon Woodhull <gordon@research.att.com>
 Maintainer: Gordon Woodhull <gordon@research.att.com>
 Description: rcloud.shiny connects a Shiny app to an RCloud server using ocaps instead of websockets

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,1 +1,5 @@
 export(rcloud.shinyApp)
+
+export(shinyApp)
+export(print.shiny.appobj)
+S3method(print, shiny.appobj)

--- a/R/rcloud.shiny.R
+++ b/R/rcloud.shiny.R
@@ -3,63 +3,105 @@ rcloud.proxy.url <- function(port, search, hash) {
   paste0('/proxy.R/', info$user, '/', info$id, ':', port, '/', search, hash)
 }
 
-rcloud.shinyApp <- function(ui, server, options) {
-  if(!requireNamespace("rcloud.web", quietly = TRUE)) {
-    stop("'rcloud.web' is needed for this function to work. Please install it.",
-         call. = FALSE)
-  }
-  if(!requireNamespace("shiny", quietly = TRUE)) {
-    stop("'shiny' is needed for this function to work. Please install it.",
-         call. = FALSE)
-  }
-  appHandlers <- NULL
-  onMessageHandler <- NULL
-  onCloseHandler <- NULL
-
+spawnApp <- function(app) {
+  
+  handlers <- list()
+  
   fakeWebSocket <- function(id) {
     list(
       send = function(msg) {
         rcloud.shiny.caps$on_message(id, msg);
       },
       onMessage = function(h) {
-        onMessageHandler <<- h
+        handlers$onMessageHandler <<- h
       },
       onClose = function(h) {
-        onCloseHandler <<- h
+        handlers$onCloseHandler <<- h
       })
   }
-
-  connect <- function(id) {
-    #rcloud.print("shiny connected")
+  
+  handlers$connect <- function(id) {
     fws <- fakeWebSocket(id)
-    appHandlers$ws(fws)
-  }
-
-  receive <- function(id, msg) {
-    #rcloud.print(paste("shiny message ", msg))
-    onMessageHandler(FALSE, msg)
+    handlers$appHandlers$ws(fws)
   }
   
-  ocaps <- list(
-    connect = rcloud.support:::make.oc(connect),
-    send = rcloud.support:::make.oc(receive)
-  );
+  handlers$receive <- function(id, msg) {
+    handlers$onMessageHandler(FALSE, msg)
+  }
   
   .GlobalEnv$.ocap.idle <- function() {
     shiny:::serviceApp()
   }
-
-  appHandlers <- shiny:::createAppHandlers(NULL, serverFuncSource)
-  app <- override.shinyApp(ui = ui, server = server)
-
+  
+  serverFuncSource <- function() {
+    app$serverFuncSource()
+  }
+  
+  handlers$appHandlers <- shiny:::createAppHandlers(NULL, serverFuncSource)
+  
   host <- rcloud.get.conf.value('host')
   appInfo <- override.runApp(app, host=nsl(host))
-
   
-  loc <- rcloud.shiny.caps$init(ocaps);
-  serverFuncSource <- function() {
-    server
+  structure(list("appInfo" = appInfo, "handlers" = handlers), 
+            class = "rcloud.shinyapp.instance")
+}
+
+shinyApp <- function(ui, server, onStart=NULL, options=list(),
+                     uiPattern="/", enableBookmarking = NULL) {
+  if(!requireNamespace("rcloud.web", quietly = TRUE)) {
+    stop("'rcloud.web' is needed for this function to work. Please install it.",
+         call. = FALSE)
   }
-  rcloud.web::rcw.result(body = paste0('<iframe src="', rcloud.proxy.url(appInfo$port, loc$search, loc$hash), '" class="rcloud-shiny" frameBorder="0" style="position: absolute; left: 0px; top: 0px; width: 100%; height: 100%;"></iframe>'))
+  override.shinyApp(ui = ui, server = server, onStart = onStart, options = options, 
+                    uiPattern = uiPattern, enableBookmarking = enableBookmarking)
+}
+
+print.shiny.appobj <- function(x, ..., view = interactive()) {
+  rcloudShinyAppInstance <- spawnApp(x)
+  if(!rcloud.shiny.caps$is_mini()) {
+    where <- paste0("rc_shinyapp_", as.integer(runif(1)*1e6))
+    rcloud.html.out(paste0(
+      "<div class=\"rcloud-shinyapp\">",
+      "<div id=\"", where, "\"></div>",
+      "</div>"))
+    where <- paste0("#", where)
+    
+    ocaps <- registerOcaps(rcloudShinyAppInstance)
+    rcloud.shiny.caps$create(where, contentDiv(buildHtml(rcloudShinyAppInstance, ocaps, style = "width: 100%; height: 400px;")))
+    invisible(x)
+  } else {
+    ocaps <- registerOcaps(rcloudShinyAppInstance)
+    invisible(rcloud.web::rcw.result(body = buildHtml(rcloudShinyAppInstance, ocaps)))
+  }
+}
+
+contentDiv <- function(what) {
+  where <- paste0("rc_shinyapp_content_", as.integer(runif(1)*1e6))
+  paste(
+    sep = "",
+    "<div class=\"rcloud-shinyapp-content\" id=\"",
+    where,
+    "\">",
+    what,
+    "</div>"
+  )
+}
+
+registerOcaps <- function(rcloudShinyAppInstance) {
+  ocaps <- list(
+    connect = rcloud.support:::make.oc(rcloudShinyAppInstance$handlers$connect),
+    send = rcloud.support:::make.oc(rcloudShinyAppInstance$handlers$receive)
+  );
+  rcloud.shiny.caps$init(ocaps);
+}
+
+buildHtml <- function(rcloudShinyAppInstance, ocaps, style = "position: absolute; left: 0px; top: 0px; width: 100%; height: 100%;") {
+  appInfo <- rcloudShinyAppInstance$appInfo
+  paste0('<iframe src="', rcloud.proxy.url(appInfo$port, ocaps$search, ocaps$hash), paste0('" class="rcloud-shiny" frameBorder="0" style="', style, '"></iframe>'))
+}
+
+rcloud.shinyApp <- function(ui, server, options = list()) {
+  app <- shinyApp(ui, server, options = options)
+  print(app)
 }
 

--- a/R/rcloud.shiny.R
+++ b/R/rcloud.shiny.R
@@ -4,9 +4,14 @@ rcloud.proxy.url <- function(port, search, hash) {
 }
 
 rcloud.shinyApp <- function(ui, server, options) {
-  library(rcloud.web)
-  library(shiny)
-
+  if(!requireNamespace("rcloud.web", quietly = TRUE)) {
+    stop("'rcloud.web' is needed for this function to work. Please install it.",
+         call. = FALSE)
+  }
+  if(!requireNamespace("shiny", quietly = TRUE)) {
+    stop("'shiny' is needed for this function to work. Please install it.",
+         call. = FALSE)
+  }
   appHandlers <- NULL
   onMessageHandler <- NULL
   onCloseHandler <- NULL
@@ -55,6 +60,6 @@ rcloud.shinyApp <- function(ui, server, options) {
   serverFuncSource <- function() {
     server
   }
-  rcw.result(body = paste0('<iframe src="', rcloud.proxy.url(appInfo$port, loc$search, loc$hash), '" class="rcloud-shiny" frameBorder="0" style="position: absolute; left: 0px; top: 0px; width: 100%; height: 100%;"></iframe>'))
+  rcloud.web::rcw.result(body = paste0('<iframe src="', rcloud.proxy.url(appInfo$port, loc$search, loc$hash), '" class="rcloud-shiny" frameBorder="0" style="position: absolute; left: 0px; top: 0px; width: 100%; height: 100%;"></iframe>'))
 }
 

--- a/R/rcloud.shiny.R
+++ b/R/rcloud.shiny.R
@@ -1,6 +1,6 @@
 rcloud.proxy.url <- function(port, search, hash) {
   info <- rcloud.session.info()
-  paste0('proxy.R/', info$user, '/', info$id, ':', port, '/', search, hash)
+  paste0('/proxy.R/', info$user, '/', info$id, ':', port, '/', search, hash)
 }
 
 rcloud.shinyApp <- function(ui, server, options) {
@@ -34,12 +34,12 @@ rcloud.shinyApp <- function(ui, server, options) {
     #rcloud.print(paste("shiny message ", msg))
     onMessageHandler(FALSE, msg)
   }
-
+  
   ocaps <- list(
     connect = rcloud.support:::make.oc(connect),
     send = rcloud.support:::make.oc(receive)
   );
-
+  
   .GlobalEnv$.ocap.idle <- function() {
     shiny:::serviceApp()
   }
@@ -50,6 +50,7 @@ rcloud.shinyApp <- function(ui, server, options) {
   host <- rcloud.get.conf.value('host')
   appInfo <- override.runApp(app, host=nsl(host))
 
+  
   loc <- rcloud.shiny.caps$init(ocaps);
   serverFuncSource <- function() {
     server

--- a/R/shiny-overrides.R
+++ b/R/shiny-overrides.R
@@ -121,7 +121,7 @@ override.renderPage <- function(ui, connection, showcase=0) {
     htmlDependency("json2", "2014.02.04", c(href="shared"), script = "json2-min.js"),
     htmlDependency("jquery", "1.12.4", c(href="shared"), script = "jquery.min.js"),
     htmlDependency("babel-polyfill", "6.7.2", c(href="shared"), script = "babel-polyfill.min.js"),
-    htmlDependency("rcloud.shiny", "0.4", c(href="/shared.R/rcloud.shiny/"), script = "rcloud.shiny.child.js"),
+    htmlDependency("rcloud.shiny", utils::packageVersion("rcloud.shiny"), c(href="/shared.R/rcloud.shiny/"), script = "rcloud.shiny.child.js"),
     htmlDependency("shiny", utils::packageVersion("shiny"), c(href="shared"),
       script = if (getOption("shiny.minified", TRUE)) "shiny.min.js" else "shiny.js",
       stylesheet = "shiny.css")

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -3,10 +3,13 @@ rcloud.shiny.caps <- NULL
 .onLoad <- function(libname, pkgname)
 {
   f <- function(module.name, module.path) {
-    path <- system.file("javascript", module.path, package="rcloud.shiny")
+    path <- system.file("javascript", module.path, package=module.name)
     caps <- rcloud.install.js.module(module.name,
                                      paste(readLines(path), collapse='\n'))
     caps
   }
   rcloud.shiny.caps <<- f("rcloud.shiny", "rcloud.shiny.js")
+  if(!is.null(rcloud.shiny.caps)) {
+    rcloud.shiny.caps$init(list());
+  }
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -8,8 +8,8 @@ rcloud.shiny.caps <- NULL
                                      paste(readLines(path), collapse='\n'))
     caps
   }
-  rcloud.shiny.caps <<- f("rcloud.shiny", "rcloud.shiny.js")
-  if(!is.null(rcloud.shiny.caps)) {
-    rcloud.shiny.caps$init(list());
-  }
+    rcloud.shiny.caps <<- f("rcloud.shiny", "rcloud.shiny.js")
+    if(!is.null(rcloud.shiny.caps)) {
+      rcloud.shiny.caps$init(list());
+    }
 }

--- a/inst/javascript/rcloud.shiny.js
+++ b/inst/javascript/rcloud.shiny.js
@@ -3,14 +3,23 @@
 var sockets_ = [];
 var ocaps_ = null;
 var title_ = "RCloud", favicon_;
+var SHINY_HTML_LOCATION = 'shared.R/rcloud.shiny/shiny.html';
+var debugEnabled = false;
+var initialized = false;
+
+function debug(msg, arg) {
+  if(debugEnabled) {
+    console.debug(msg, arg);
+  }
+}
 
 function fakeWebSocket() {
     var fws = {
         readyState: false,
         send: function(msg) {
-            console.log("client to Shiny: ", JSON.parse(msg));
+            debug("client to Shiny: ", JSON.parse(msg));
             ocaps_.sendAsync(id, msg).then(function(response) {
-                console.log("Shiny response: ", response);
+                debug("Shiny response: ", response);
             });
         }
     };
@@ -24,32 +33,46 @@ function fakeWebSocket() {
     return fws;
 }
 
+function isMini() {
+  return window.document.location.pathname.endsWith(SHINY_HTML_LOCATION);
+}
+
 return {
     init: function(ocaps, k) {
-        console.log('shiny js parent init');
-        ocaps_ = RCloud.promisify_paths(ocaps, [["connect"], ["send"]]);
-
-        window.rcloud.create_fake_shiny_websocket = function() {
-            return fakeWebSocket();
-        };
-
-        window.setInterval(function() {
-            $('iframe.rcloud-shiny').each(function() {
-                var shtitle = this.contentWindow.document.title;
-                if(shtitle !== title_)
-                    document.title = title_ = shtitle;
-                var favlink = this.contentWindow.document.querySelector("link[rel*='icon']");
-                if(!favicon_ && favlink) {
-                    // adapted from http://stackoverflow.com/questions/260857/changing-website-favicon-dynamically#260876
-                    var link = document.querySelector("link[rel*='icon']") || document.createElement('link');
-                    link.type = 'image/x-icon';
-                    link.rel = favlink.rel;
-                    link.href = favlink.href;
-                    document.getElementsByTagName('head')[0].appendChild(link);
-                    favicon_ = link;
-                }
-            });
-        }, 2000);
+         if(isMini()) {
+            ocaps_ = RCloud.promisify_paths(ocaps, [["connect"], ["send"]]);
+            if(!initialized) {
+                  window.rcloud.create_fake_shiny_websocket = function() {
+                      return fakeWebSocket();
+                  };
+          
+                  window.setInterval(function() {
+                      $('iframe.rcloud-shiny').each(function() {
+                          var shtitle = this.contentWindow.document.title;
+                          if(shtitle !== title_)
+                              document.title = title_ = shtitle;
+                          var favlink = this.contentWindow.document.querySelector("link[rel*='icon']");
+                          if(!favicon_ && favlink) {
+                              // adapted from http://stackoverflow.com/questions/260857/changing-website-favicon-dynamically#260876
+                              var link = document.querySelector("link[rel*='icon']") || document.createElement('link');
+                              link.type = 'image/x-icon';
+                             link.rel = favlink.rel;
+                             link.href = favlink.href;
+                             document.getElementsByTagName('head')[0].appendChild(link);
+                             favicon_ = link;
+                        }
+                     });
+                 }, 2000);
+             }
+         } else {
+           RCloud.UI.share_button.add({ 
+                   'shiny.html': {
+                        sort: 4000,
+                        page: SHINY_HTML_LOCATION
+                    }
+          });
+        }
+        initialized = true;
         k({hash: window.location.hash, search: window.location.search});
     },
     on_message: function(id, msg, k) {
@@ -58,11 +81,11 @@ return {
             // instead of pseudo-scalars
             if(msg.length > 1) console.log('rcloud.shiny: whoops, more than one element?');
             msg = msg[0];
-        };
+        }
         var msj = JSON.parse(msg);
-        console.log("Shiny to client: ", msj);
+        debug("Shiny to client: ", msj);
         if(msj && msj.values && msj.values.mytable1 && msj.values.mytable1.x && msj.values.mytable1.x.options)
-            console.log("DT options: ", msj.values.mytable1.x.options);
+            debug("DT options: ", msj.values.mytable1.x.options);
         // [id] ?
         sockets_[0].onmessage({data:msg});
         k();

--- a/inst/javascript/rcloud.shiny.js
+++ b/inst/javascript/rcloud.shiny.js
@@ -1,3 +1,5 @@
+
+
 ((function() {
 
 var sockets_ = [];
@@ -34,9 +36,105 @@ function fakeWebSocket() {
 }
 
 function isMini() {
-  return window.document.location.pathname.endsWith(SHINY_HTML_LOCATION);
+  return RCloud.UI.advanced_menu.add === null || RCloud.UI.advanced_menu.add === undefined;
 }
 
+function getDocHeight(Di) {
+    var D = Di[0];
+
+    if (Di.find('body').css('overflow') === 'hidden') {
+        return Math.max(
+            D.documentElement.offsetHeight,
+            D.documentElement.clientHeight
+        );
+
+    } else {
+        return Math.max(
+            Math.max(D.body.scrollHeight, D.documentElement.scrollHeight),
+            Math.max(D.body.offsetHeight, D.documentElement.offsetHeight),
+            Math.max(D.body.clientHeight, D.documentElement.clientHeight)
+        );
+    }
+}
+
+var lastWidths = { };
+
+function size_this(div, reset) {
+    // Check if the widget has a <body> already. If not, we need to wait
+    // a bit
+
+    var Di = $(div).find('iframe').contents();
+    var D = Di[0];
+
+    if (!div.id) {
+        // Do nothing if the div is not there at all
+
+    } else if (!D || !D.body || !Di.is('visible')) {
+        setTimeout(function() { size_this(div, reset); }, 100);
+
+    } else {
+        // Check if the width of the iframe is different. If not, then
+        // we don't need to do anything.
+        var rcid = div.id;
+        var width = $(div).find('iframe').width();
+        if (reset || !(rcid in lastWidths) || (lastWidths[rcid] != width)) {
+            var h = getDocHeight(Di);
+            $(div).find('iframe').height(h);
+            $(div).find('iframe').attr('height', h);
+        }
+        lastWidths[rcid] = width;
+    }
+}
+
+function resize_all(reset) {
+    var widgets = $('.rcloud-shinyapp-content');
+    $.map(
+        widgets,
+        function(w) {
+            setTimeout(function() { size_this(w, reset) }, 200);
+        }
+    );
+
+    return widgets.length;
+}
+
+var hooks = false;
+
+function add_hooks() {
+    if (!hooks) {
+        hooks = true;
+        window.addEventListener('resize', resize_all, true);
+    }
+}
+
+// The resizer is mainly for mini.html, but might be handy for
+// notebook as well, if some widgets resize very slowly.
+
+var lastWidth = window.innerWidth;
+
+$(document).ready(function() {
+    add_hooks();
+    function resizer(reset) {
+        var num_widgets = resize_all(reset);
+        var interval = 200;
+        if (num_widgets > 0) {
+            setTimeout(resizer, 5000);
+        } else {
+            setTimeout(function() { resizer(true) }, interval);
+        }
+    }
+    resizer(lastWidth < window.innerWidth);
+    lastWidth = window.innerWidth;
+});
+
+function initWidget(div, html, k) {
+    Promise.resolve(undefined)
+            .then(function() {
+                $(div).html(html);
+                setTimeout(function() { size_this($(div), true); }, 100);
+            });
+    k(null, div);
+}
 return {
     init: function(ocaps, k) {
          if(isMini()) {
@@ -54,8 +152,8 @@ return {
                           var favlink = this.contentWindow.document.querySelector("link[rel*='icon']");
                           if(!favicon_ && favlink) {
                               // adapted from http://stackoverflow.com/questions/260857/changing-website-favicon-dynamically#260876
-                              var link = document.querySelector("link[rel*='icon']") || document.createElement('link');
-                              link.type = 'image/x-icon';
+                             var link = document.querySelector("link[rel*='icon']") || document.createElement('link');
+                             link.type = 'image/x-icon';
                              link.rel = favlink.rel;
                              link.href = favlink.href;
                              document.getElementsByTagName('head')[0].appendChild(link);
@@ -65,12 +163,18 @@ return {
                  }, 2000);
              }
          } else {
-           RCloud.UI.share_button.add({ 
-                   'shiny.html': {
-                        sort: 4000,
-                        page: SHINY_HTML_LOCATION
-                    }
-          });
+            ocaps_ = RCloud.promisify_paths(ocaps, [["connect"], ["send"]]);
+            if(!initialized) {
+                  window.rcloud.create_fake_shiny_websocket = function() {
+                      return fakeWebSocket();
+                  };
+                 RCloud.UI.share_button.add({ 
+                         'shiny.html': {
+                              sort: 4000,
+                              page: SHINY_HTML_LOCATION
+                          }
+                });
+            }
         }
         initialized = true;
         k({hash: window.location.hash, search: window.location.search});
@@ -89,6 +193,14 @@ return {
         // [id] ?
         sockets_[0].onmessage({data:msg});
         k();
-    }
+    },
+    create: function(div, html, k) {
+        initWidget(div, html, k);
+    },
+
+    is_mini: function(k) {
+      k(null, isMini());
+    } 
+    
 };
 })()) /*jshint -W033 */ // this is an expression not a statement

--- a/inst/www/css/rcloud-shiny.css
+++ b/inst/www/css/rcloud-shiny.css
@@ -1,0 +1,203 @@
+body {
+  margin: 0;
+  overflow: hidden; }
+
+body.modal-open,
+.modal-open .navbar-fixed-top,
+.modal-open .navbar-fixed-bottom {
+  margin-right: 15px; }
+
+.modal {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1040;
+  display: none;
+  overflow: auto;
+  overflow-y: scroll;
+  color: #333333; }
+  .modal h1 {
+    font-size: 26px;
+    font-weight: 500;
+    line-height: 1.1;
+    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; }
+  .modal p {
+    margin: 0 0 10px;
+    font-family: sans-serif;
+    font-size: 12px;
+    line-height: 17px; }
+  .modal .btn {
+    display: inline-block;
+    padding: 6px 12px;
+    margin-bottom: 0;
+    font-family: sans-serif;
+    font-size: 14px;
+    font-weight: normal;
+    line-height: 1.428571429;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: middle;
+    cursor: pointer;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    -o-user-select: none;
+    user-select: none; }
+  .modal .btn:focus {
+    outline: thin dotted #333;
+    outline: 5px auto -webkit-focus-ring-color;
+    outline-offset: -2px; }
+  .modal .btn:hover,
+  .modal .btn:focus {
+    color: #333333;
+    text-decoration: none; }
+  .modal .btn:active,
+  .modal .btn.active {
+    background-image: none;
+    outline: 0;
+    -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+    box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125); }
+  .modal .btn-primary {
+    color: #ffffff;
+    background-color: #428bca;
+    border-color: #357ebd; }
+  .modal .btn-primary:hover,
+  .modal .btn-primary:focus,
+  .modal .btn-primary:active,
+  .modal .btn-primary.active,
+  .modal .open .dropdown-toggle.btn-primary {
+    color: #ffffff;
+    background-color: #3276b1;
+    border-color: #285e8e; }
+  .modal .btn-primary:active,
+  .modal .btn-primary.active {
+    background-image: none; }
+  .modal .btn-primary.disabled,
+  .modal .btn-primary[disabled],
+  .modal .btn-primary.disabled:hover,
+  .modal .btn-primary[disabled]:hover,
+  .modal .btn-primary.disabled:focus,
+  .modal .btn-primary[disabled]:focus,
+  .modal .btn-primary.disabled:active,
+  .modal .btn-primary[disabled]:active,
+  .modal .btn-primary.disabled.active,
+  .modal .btn-primary[disabled].active {
+    background-color: #428bca;
+    border-color: #357ebd; }
+
+.modal.fade .modal-dialog {
+  -webkit-transform: translate(0, -25%);
+  -ms-transform: translate(0, -25%);
+  transform: translate(0, -25%);
+  -webkit-transition: -webkit-transform 0.3s ease-out;
+  -moz-transition: -moz-transform 0.3s ease-out;
+  -o-transition: -o-transform 0.3s ease-out;
+  transition: transform 0.3s ease-out; }
+
+.modal.in .modal-dialog {
+  -webkit-transform: translate(0, 0);
+  -ms-transform: translate(0, 0);
+  transform: translate(0, 0); }
+
+.modal-dialog {
+  z-index: 1050;
+  width: auto;
+  padding: 10px;
+  margin-right: auto;
+  margin-left: auto; }
+
+.modal-content {
+  position: relative;
+  background-color: #ffffff;
+  border: 1px solid #999999;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 6px;
+  outline: none;
+  -webkit-box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
+  background-clip: padding-box; }
+
+.modal-backdrop {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1030;
+  background-color: #000000; }
+
+.modal-backdrop.fade {
+  opacity: 0;
+  filter: alpha(opacity=0); }
+
+.modal-backdrop.in {
+  opacity: 0.5;
+  filter: alpha(opacity=50); }
+
+.modal-header {
+  min-height: 16.428571429px;
+  padding: 15px;
+  border-bottom: 1px solid #e5e5e5; }
+
+.modal-header .close {
+  margin-top: -2px; }
+
+.modal-title {
+  margin: 0;
+  line-height: 1.428571429; }
+
+.modal-body {
+  position: relative;
+  padding: 20px; }
+
+.modal-footer {
+  padding: 19px 20px 20px;
+  margin-top: 15px;
+  text-align: right;
+  border-top: 1px solid #e5e5e5; }
+
+.modal-footer:before,
+.modal-footer:after {
+  display: table;
+  content: " "; }
+
+.modal-footer:after {
+  clear: both; }
+
+.modal-footer:before,
+.modal-footer:after {
+  display: table;
+  content: " "; }
+
+.modal-footer:after {
+  clear: both; }
+
+.modal-footer .btn + .btn {
+  margin-bottom: 0;
+  margin-left: 5px; }
+
+.modal-footer .btn-group .btn + .btn {
+  margin-left: -1px; }
+
+.modal-footer .btn-block + .btn-block {
+  margin-left: 0; }
+
+@media screen and (min-width: 768px) {
+  .modal-dialog {
+    right: auto;
+    left: 50%;
+    width: 600px;
+    padding-top: 30px;
+    padding-bottom: 30px; }
+  .modal-content {
+    -webkit-box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5); } }
+
+#fatal-dialog .modal-content {
+  background-color: #f2dede; }
+
+/*# sourceMappingURL=rcloud-shiny.css.map */

--- a/inst/www/js/require-shiny.js
+++ b/inst/www/js/require-shiny.js
@@ -1,0 +1,40 @@
+requirejs_config_obj = {
+    "baseUrl": "/lib/js",
+    waitSeconds: 30,
+    paths: {
+        "jquery": "../../../shared.R/shiny/shared/jquery",
+        "rcloud_bundle": "../../../js/rcloud_bundle",
+        "mini": "../../mini",
+        "selectize": "../../../shared.R/shiny/shared/selectize/js/selectize.min",
+        "datatables": "../../../shared.R/shiny/shared/datatables/js/jquery.dataTables.min"
+    },
+    "shim": {
+        datatables: {
+            deps: ['jquery'],
+            exports: "jQuery.fn.dataTable"
+        },
+        "jquery-ui": ["jquery"],
+        "jquery.cookies.2.2.0": ["jquery"],
+        "rserve": ["underscore"],
+        "mini": ["rcloud_bundle"],
+        "bootstrap": ["jquery-ui", "jquery"],
+        "rcloud_bundle": ["jquery.cookies.2.2.0", "rserve"]
+    }
+};
+
+var deps = [
+    "bluebird", "underscore", "d3", "jquery", "jquery-ui", "bootstrap", "rserve", "mini", "rcloud_bundle", "datatables", "selectize"
+];
+
+function start_require(deps) {
+    require(deps,
+        function(Promise, _, d3) {
+            window.Promise = Promise;
+            window._ = _;
+            window.d3 = d3;
+            main();
+        });
+}
+
+requirejs.config(requirejs_config_obj);
+start_require(deps);

--- a/inst/www/shiny.html
+++ b/inst/www/shiny.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>RCloud</title>
+    <link rel="shortcut icon" type="image/x-icon" href="favicon.png" />
+    <script type="text/javascript" data-main="js/require-shiny.js" src="/lib/js/require.js"></script>
+    <link rel="stylesheet" type="text/css" href="css/rcloud-shiny.css" />
+  </head>
+  <body>
+  </body>
+</html>


### PR DESCRIPTION
Note: This builds on top of https://github.com/att/rcloud.shiny/pull/19 (this is why there are so many commits)

Actual implementation is in this commit:
https://github.com/MangoTheCat/rcloud.shiny/commit/e0fea940c6847ec56f23fdd4250be1e7a432ca01

The solution simply masks shinyApp function from shiny package and introduces the print.shiny.appobj method which, depending on the mode in which notebook is executed, uses rcloud.web::rcw.result or returns an iframe to print the shiny.appobj.

Example that works in both: mini/shiny.html and in edit mode:

[Dashboarding-shiny.html-AAA Tutorial Example in the cell.gist.zip](https://github.com/att/rcloud.shiny/files/1139159/Dashboarding-shiny.html-AAA.Tutorial.Example.in.the.cell.gist.zip)


Unfortunately I had to bring back strong dependency on shiny - without it the 'shinyApp' function was not reliably masked by our implementation. I also looked if we can get rid of our override.shinyApp and use shinyApp from shiny package, but unfortunately this is not possible. So, unless there is a way to ensure that rcloud.shiny is always in front of shiny package on the namespace search path, we will need to go ahead with eagerly loading shiny package.

Supporting shiny apps in a cell required me to bring in some functions from htmlwidgets, for now these are copies (with some small changes). We could consider refactoring htmlwidgets.js so functions from there can be shared with rcloud.shiny, or making them generic enough so they are part of rcloud core. This however I would address with a separate issue to facilitate management/review of that change - as it will be cross-project change focusing on div classes and resizing and it will in fact add a new dependency to rcloud.shiny on rcloud.htmlwidgets...




