### PR TITLE
Add missing 'close' method to shiny socket implementation, FIX #21

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -13,3 +13,5 @@ rcloud.shiny.caps <- NULL
     rcloud.shiny.caps$init(list());
   }
 }
+
+rcloud.shiny.debugMsg <- function(content) rcloud.shiny.caps$debugMsg(content)

--- a/inst/javascript/rcloud.shiny.js
+++ b/inst/javascript/rcloud.shiny.js
@@ -84,11 +84,28 @@ return {
         }
         var msj = JSON.parse(msg);
         debug("Shiny to client: ", msj);
+
         if(msj && msj.values && msj.values.mytable1 && msj.values.mytable1.x && msj.values.mytable1.x.options)
             debug("DT options: ", msj.values.mytable1.x.options);
         // [id] ?
         sockets_[0].onmessage({data:msg});
         k();
+    }, 
+    on_close: function(id, msg, k) {
+        console.log("Closing Shiny socket: ", msg);
+        if(msg) {
+          var msj = JSON.parse(msg);
+        
+          if(msj.type && msj.type === 'rcloud-shiny-error') {
+            RCloud.UI.fatal_dialog(msj.msg, 'Close');
+          }
+        }
+        sockets_[0].onclose();
+        k();
+    }, 
+    debugMsg: function(content, k) {
+      debug("rcloud.shiny R: ", content);
+      k();
     }
 };
 })()) /*jshint -W033 */ // this is an expression not a statement


### PR DESCRIPTION
When an unhandled error occurs during execution of shinyApp, Shiny will close the shiny socket. Because the 'close' function was missing from our implementation of the socket, a stacktrace covering internal shiny functions was produced and original error was masked.

This change introduces the missing function and also makes sure that Shiny front-end is notified about socket being closed (so the greyed out overlay is displayed in the UI preventing users from interacting with widgets). 

Because Shiny just logs the unhandled errors as warnings and does not pass the reason/error object to 'close' function, our implementation of 'close' socket function extracts the original error message from function call stack so it can be presented to the user in fatal_dialog.