### PR TITLE
Allow for specifying custom renderer to display shinyApp

### DIFF
--- a/R/shiny-overrides.R
+++ b/R/shiny-overrides.R
@@ -119,13 +119,18 @@ override.renderPage <- function(ui, connection, showcase=0) {
 
   shiny_deps <- list(
     htmlDependency("json2", "2014.02.04", c(href="shared"), script = "json2-min.js"),
-    htmlDependency("jquery", "1.12.4", c(href="shared"), script = "jquery.min.js"),
-    htmlDependency("babel-polyfill", "6.7.2", c(href="shared"), script = "babel-polyfill.min.js"),
+    htmlDependency("jquery", "1.12.4", c(href="shared"), script = "jquery.min.js"))
+    if(utils::compareVersion(as.character(utils::packageVersion('shiny')), "1.0.1") < 0) {
+      # Shiny >= 1.0.1 doesn't include babel-polyfill
+      shiny_deps <- c(shiny_deps, list(
+        htmlDependency("babel-polyfill", "6.7.2", c(href="shared"), script = "babel-polyfill.min.js")))
+    }
+  shiny_deps <- c(shiny_deps,list(
     htmlDependency("rcloud.shiny", utils::packageVersion("rcloud.shiny"), c(href="/shared.R/rcloud.shiny/"), script = "rcloud.shiny.child.js"),
     htmlDependency("shiny", utils::packageVersion("shiny"), c(href="shared"),
       script = if (getOption("shiny.minified", TRUE)) "shiny.min.js" else "shiny.js",
       stylesheet = "shiny.css")
-  )
+  ))
   html <- renderDocument(ui, shiny_deps, processDep = createWebDependency)
   shiny:::writeUTF8(html, con = connection)
 }

--- a/inst/javascript/rcloud.shiny.js
+++ b/inst/javascript/rcloud.shiny.js
@@ -34,7 +34,7 @@ function fakeWebSocket() {
 }
 
 function isMini() {
-  return window.document.location.pathname.endsWith(SHINY_HTML_LOCATION);
+  return !RCloud.UI.advanced_menu.add;
 }
 
 return {
@@ -87,8 +87,8 @@ return {
 
         if(msj && msj.values && msj.values.mytable1 && msj.values.mytable1.x && msj.values.mytable1.x.options)
             debug("DT options: ", msj.values.mytable1.x.options);
-        // [id] ?
-        sockets_[0].onmessage({data:msg});
+
+        sockets_[id].onmessage({data:msg});
         k();
     }, 
     on_close: function(id, msg, k) {
@@ -100,7 +100,7 @@ return {
             RCloud.UI.fatal_dialog(msj.msg, 'Close');
           }
         }
-        sockets_[0].onclose();
+        sockets_[id].onclose();
         k();
     }, 
     debugMsg: function(content, k) {


### PR DESCRIPTION
Add support for multiple shiny sockets, which are used by rmarkdown to re-render page when window size changes significantly.
Make sure that 404 errors are not thrown for babel-polyfill.js dependency when RCloud has shiny 1.0.1+ installed.