### PR TITLE
Enable shiny shutdown hooks.

### DIFF
--- a/R/rcloud.shiny.R
+++ b/R/rcloud.shiny.R
@@ -7,6 +7,24 @@ rcloud.shinyApp <- function(ui, server, onStart = NULL, options = list(), uiPatt
   rcloud.shinyAppInternal(ui, server, onStart = onStart, options = options, uiPattern = uiPattern)
 }
 
+.debug.msg <- function(msg = "", debug.enabled = .isDebugEnabled(), debug.file = .getLogFile()) {
+  if(debug.enabled && !is.null(debug.file)) {
+    cat(msg, file = debug.file, sep = "\n", append = TRUE)
+  }
+}
+
+.isDebugEnabled <- function() {
+  OPT <- "rcloud.shiny.debug.enabled"
+  if(rcloud.support:::nzConf(OPT)) {
+    return(as.logical(rcloud.support:::getConf(OPT)))
+  }
+  return(FALSE)
+}
+
+.getLogFile <- function() {
+  file.path(rcloud.support:::pathConf("tmp.dir"), "rcloud.shiny.log")
+}
+
 rcloud.shinyAppInternal <- function(ui, server, onStart = NULL, options = list(), uiPattern = "/", renderer = function(url) { rcloud.web::rcw.result(body = paste0('<iframe src="', url, '" class="rcloud-shiny" frameBorder="0" style="position: absolute; left: 0px; top: 0px; width: 100%; height: 100%;"></iframe>'))}) {
   library(rcloud.web)
   library(shiny)
@@ -35,29 +53,81 @@ rcloud.shinyAppInternal <- function(ui, server, onStart = NULL, options = list()
           error <- get("e", envir=parentEnv)
           errorMsg <- jsonlite::toJSON(list(type="rcloud-shiny-error", msg=as.character(error)), auto_unbox=TRUE)
         }
-        rcloud.shiny.caps$on_close(id, errorMsg)
-        onCloseHandler()
+        tryCatch(rcloud.shiny.caps$on_close(id, errorMsg), error = function(e) {
+          warning(paste("Failed to notify frontent about closed socket: " , e, "\n"))
+        })
+        
+        tryCatch(onCloseHandler(), error = function(e) {
+          warning(paste("Failed to execute socket onCloseHandler: " , e, "\n"))
+        })
       });
   }
   
+  fws <- NULL
+
   connect <- function(id) {
     rcloud.shiny.debugMsg("Shiny connected")
-    fws <- fakeWebSocket(id)
+    fws <<- fakeWebSocket(id)
     appHandlers$ws(fws)
   }
-  
+
   receive <- function(id, msg) {
     rcloud.shiny.debugMsg(paste("Shiny message", msg))
     onMessageHandler(FALSE, msg)
   }
-  
+
   ocaps <- list(
     connect = rcloud.support:::make.oc(connect),
     send = rcloud.support:::make.oc(receive)
   )
+
+
+  executeExitCallbacks <- function(exit.env) {
+    
+    .debug.msg("Running shiny shutdown callbacks")
+    
+    if(!is.null(fws)) {
+      tryCatch(fws$close(), error = function(e) {
+        errMsg <- paste("Failed to close shiny socket:", as.character(e))
+        warning(errMsg)
+        if (exit.env$debug.enabled) {
+          .debug.msg(errMsg)
+          .debug.msg(traceback())
+        }
+      })
+    }
+    
+    if( exit.env$exit.callbacks.executed ) {
+      warning("Shiny app exit callbacks already executed, skipping")
+      return(exit.env$exit.callbacks.executed)
+    }
+    
+    .debug.msg(paste0("Number of callback functions: ", length(exit.env$exit.callbacks)))
+    
+    lapply(exit.env$exit.callbacks, function(callback) {
+      tryCatch(callback(), error = function(e) {
+        errMsg <- paste("Failed to execute shiny exit callback: " , as.character(e), "\n")
+        warning(errMsg)
+        .debug.msg(errMsg)
+      })
+    })
+    
+    .debug.msg("Processing shiny shutdown callbacks completed.")
+    
+    exit.env$exit.callbacks.executed <- TRUE
+  }
+  
+  exit.env <- new.env()
+  exit.env$exit.callbacks <- c()
+  exit.env$exit.callbacks.executed <- FALSE
   
   .GlobalEnv$.ocap.idle <- function() {
     shiny:::serviceApp()
+    if (isTRUE(shiny:::.globals$stopped)) {
+      tryCatch(executeExitCallbacks(exit.env), error=function(e) {
+        .debug.msg(paste("Error when shutting down shiny:", as.character(e)))
+      })
+    }
   }
   
   appHandlers <- shiny:::createAppHandlers(NULL, serverFuncSource)
@@ -69,9 +139,35 @@ rcloud.shinyAppInternal <- function(ui, server, onStart = NULL, options = list()
   extraArgs <- options
   extraArgs <- extraArgs[which(names(extraArgs) %in% extraArgNames)]
   
-  host <- rcloud.get.conf.value('host')
-  appInfo <- do.call(override.runApp, c(list(app, host=nsl(host)), extraArgs))
+  extraArgs$exit.handler <- function(expr, add = FALSE, env = parent.frame()) {
+    if(add) {
+      exit.env$exit.callbacks <- c(exit.env$exit.callbacks, function() { eval(deparse(expr), envir = env) })
+    } else {
+      exit.env$exit.callbacks <- c(function() {eval(deparse(expr), envir = env)})
+    }
+  }
   
+  
+  host <- rcloud.get.conf.value('host')
+  appInfo <- tryCatch( {
+    do.call(override.runApp, c(list(app, host=nsl(host)), extraArgs))
+  }, 
+  error = function(o) structure(list(error=o$message), class="shiny-startup-error"))
+  
+  
+  if (inherits(appInfo, "shiny-startup-error")) {
+    executeExitCallbacks(exit.env)
+    stop(paste0("Failed to startup shiny application. ", appInfo$error))
+  } else {
+    f <- .GlobalEnv$.Rserve.done
+    session <- rcloud.support:::.session
+    .GlobalEnv$.Rserve.done <- function(...) {
+      executeExitCallbacks(exit.env)
+      if (is.function(f)) {
+        f(...)
+      }
+    }
+  }
   
   loc <- rcloud.shiny.caps$init(ocaps);
   serverFuncSource <- function() {


### PR DESCRIPTION
Introduce a shutdown handler to which callback functions can be registered.
The handler is then invoked if/when:

* shiny socket is closed
* startup of shiny app fails
* RCloud session is closed